### PR TITLE
rewrite s3cat from scratch

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,3 @@
 [flake8]
 max-line-length=8192
-disable: C0111, C0103, C0121, R0913
+disable: C0111, C0103, C0121, R0913, W0702, R0914

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,3 +1,3 @@
 [flake8]
 max-line-length=8192
-disable: C0111, C0103, C0121, R0913
+disable: C0111, C0103, C0121, R0913, W0702, R0914

--- a/README.md
+++ b/README.md
@@ -1,3 +1,92 @@
 # s3mi
 Transfer big files fast between S3 and EC2.
 Pronounced "semi".
+
+# INSTALLATION
+
+pip install 'git+git://github.com/chanzuckerberg/s3mi.git'
+
+# COMMANDS
+
+
+s3mi cp s3://huge_file destination
+
+    -- fast 2GB/sec download from S3
+
+    -- may be constrained by destination write bandwidth
+
+        * when the destination is an EBS gp2 volume,
+          write bandwidth is only 160 MB/sec
+
+        * RAID can increase that to 1.75GB/sec
+          on select instance types [1]
+
+
+s3mi cat s3://huge_file | some_command
+
+    -- use cases
+
+        * expand uncompressed archives
+
+            s3cat s3://gigabytes.tar | tar xf -
+
+        * stream through a really fast computation
+
+            s3cat s3://gigabytes_of_text | wc -l
+
+    -- do not use for expanding compressed archives
+
+        * typically gated by decompression or
+          by destination, not by download
+
+    -- use only when piping through another command
+
+        * s3mi cp is better than s3mi cat
+          for direct downloads
+
+s3mi raid volume-name [N] [volume-size]
+
+    Use RAID to overcome destination bandwidth limits.
+
+    Example:
+
+        s3mi raid my_fast_raid 7 214GB
+
+    Creates 7 x 214GB EBS gp2 volumes, RAID0s those together,
+    and mounts the set on /mnt/my_fast_raid.
+
+    After the instance is restarted or terminated, the RAID array
+    will persist, but will not be mounted.  To remount on either the
+    original instance, or on another instance after the original
+    instance has been terminated, just rerun the same command
+
+        s3mi raid my_fast_raid 7 214GB
+
+    Optimal configuration:
+
+    The ideal N is the per-instance EBS bandwidth limit [1]
+    divided by the per-volume EBS bandwidth limit [2].
+
+    The ideal volume-size is chosen to ensure the per-volume
+    bandwidth limit can be met in steady state [2].
+
+    In Dec 2017, the ideal settings are as follows.
+
+        c5.18xlarge with gp2 EBS
+
+            N >= 7
+            volume-size >= 214 GB
+
+        i3.16xlarge with gp2 EBS
+
+            N >= 11
+            volume-size >= 214 GB
+
+
+#REFERENCES
+
+  1. Per-instance EBS bandwidth limits
+	http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-ec2-config.html
+
+	2. Per-volume EBS bandwidth limits
+	http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html

--- a/scripts/s3cp.py
+++ b/scripts/s3cp.py
@@ -1,214 +1,30 @@
 #!/usr/bin/env python
-#
-# Tested under python 2.7, 3.5, 3.6.
-#
-# Copyright (c) 2017 Chan Zuckerberg Initiative, see LICENSE.
 
-help_text="""
-S3MI tools s3cp
+from subprocess import check_call
 
-Usage similar to "aws s3 cp", but 10x faster for large files (10+ GB)
-on machines that have 10+ Gbps connection to S3.
-
-Examples:
-
-    # Copy from S3 to local file
-    s3cp.py s3://my_bucket/my_big_file /mnt/instance_local_path/my_big_file
-
-    # Stream from S3 through tar
-    s3cp.py s3://my_bucket/my_big_file.tar.bz2 - | lbzip2 -dc | tar xvf -
-
-License:
-    https://github.com/chanzuckerberg/s3mi/blob/master/LICENSE
-"""
-
-import threading
-import multiprocessing
-import subprocess
-import os
 import sys
-import time
-
-EXABYTE = 2**50
-
-# The goal is to stream from S3 at 2GB/sec.
-# As each request is limited to 1 Gbit/sec, we need 16+ concurrent requests.
-MAX_CONCURRENT_REQUESTS = 36
-
-# Max RAM required = MAX_PENDING_APPENDS * MAX_SEGMENT_SIZE
-MAX_PENDING_APPENDS = 512
-MAX_SEGMENT_SIZE = 128*1024*1024
-
-FILE_BUFFER_SIZE = 256*1024*1024
-
-# Max time in seconds without a single chunk completing its fetch.
-TIMEOUT = 120
-
-def tsprint(msg):
-    sys.stderr.write(msg)
-    sys.stderr.write("\n")
-
-def num_segments(file_size):
-    return (file_size + MAX_SEGMENT_SIZE - 1) // MAX_SEGMENT_SIZE
-
-def segment_start(n, N, size):
-    assert size < EXABYTE, "Sizes over an exabyte get squished by conversion to 64-bit float."
-    return int(size * (float(n) / float(N)))
-
-def part_filename(destination, n, N):
-    return "part.{N}.{n:06d}.{destination}".format(destination=destination, N=N, n=n)
-
-class PriorErrors(Exception):
-    pass
-
-def concatenate_chunk(destination, segment_bytes):
-    with open(destination, "ab", FILE_BUFFER_SIZE) as dest_file:
-        dest_file.write(segment_bytes)
-
-def stream_chunk(segment_bytes):
-    sys.stdout.write(segment_bytes)
-
-def set_state(status, n, state, lock):
-    try:
-        with lock:
-            last_state = status.get(n, 'lost in the weeds')
-            if state != 'failed' and status.get(-1) != None:
-                if state != 'succeeded':
-                    tsprint("Terminating part {n} after {state} due to erorr in part {failed_n}.".format(
-                        n=n, state=last_state, failed_n=status[-1]))
-                raise PriorErrors()
-            if state == 'failed' and status.get(-1) == None:
-                tsprint("Part {n} failed after {state}.".format(n=n, state=last_state))
-                status[-1] = n
-            status[n] = state
-    except PriorErrors:
-        raise
-    except:
-        pass
+import os
+import traceback
 
 def safe_remove(f):
     try:
         if os.path.exists(f):
             os.remove(f)
     except:
+        traceback.print_exc()
         pass
 
-def fetch_chunk(s3_bucket, s3_key, destination, n, N, size, status, last_semaphore, next_semaphore, requests_semaphore, appends_semaphore, lock):
-    try:
-        released = False
-        first = segment_start(n, N, size)
-        last = segment_start(n + 1, N, size) - 1  # aws api wants inclusive bounds
-        part = part_filename(destination, n, N)
-        command_str = "aws s3api get-object --range bytes={rfrom}-{rto} --bucket {bucket} --key {key} {part}".format(
-            rfrom=first, rto=last, bucket=s3_bucket, key=s3_key, part=part)
-        set_state(status, n, 'removing temporary file', lock)
-        safe_remove(part)
-        os.mkfifo(part)
-        set_state(status, n, 'fetching', lock)
-        with open("/dev/null", "ab") as devnull:
-            fetcher = subprocess.Popen(command_str.split(), stdout=devnull)
-        with open(part, 'rb') as pf:
-            segment_bytes = pf.read()
-        if fetcher.wait() != 0:
-            raise CalledProcessError
-        released = True
-        requests_semaphore.release()
-        safe_remove(part)
-        if last_semaphore:
-            set_state(status, n, "waiting for part {previous} to finish".format(previous=(n - 1)), lock)
-            last_semaphore.acquire()
-        set_state(status, n, 'concatenating', lock)
-        if destination == "-":  # streaming mode
-            stream_chunk(segment_bytes)
-        else:
-            concatenate_chunk(destination, segment_bytes)
-        set_state(status, n, 'succeeded', lock)
-    except PriorErrors:
-        pass
-    except:
-        set_state(status, n, 'failed', lock)
-    finally:
-        if not released:
-            requests_semaphore.release()
-            safe_remove(part)
-        appends_semaphore.release()
-        next_semaphore.release()
 
-def get_file_size(s3_uri):
-    command_str = "aws s3 ls {s3_uri}".format(s3_uri=s3_uri)
-    tsprint(command_str)
-    result = subprocess.check_output(command_str.split())
-    return int(result.split()[2])
+def tsprint(msg):
+    sys.stderr.write(msg)
+    sys.stderr.write("\n")
 
-def s3_bucket_and_key(s3_uri):
-    prefix = "s3://"
-    assert s3_uri.startswith(prefix)
-    return s3_uri[len(prefix):].split("/", 1)
-
-def main(s3_uri, destination):
-    s3_uri = sys.argv[1]
-    file_size = get_file_size(s3_uri)
-    tsprint("File size is {:3.1f} GB ({} bytes).".format(file_size/(2**30), file_size))
-    s3_bucket, s3_key = s3_bucket_and_key(s3_uri)
-    status = multiprocessing.Manager().dict()
-    lock = multiprocessing.RLock()
-    requests_semaphore = multiprocessing.Semaphore(MAX_CONCURRENT_REQUESTS)
-    appends_semaphore = multiprocessing.Semaphore(MAX_PENDING_APPENDS)
-    last_semaphore = None
-    N = num_segments(file_size)
-    tsprint("Fetching {} segments.".format(N))
-    if destination == "-":
-        sys.stdout = os.fdopen(sys.stdout.fileno(), 'ab', FILE_BUFFER_SIZE)
-        destination_download = destination
-    else:
-        destination_download = destination + ".download"
-        safe_remove(destination_download)
-    for n in range(N):
-        error = False
-        timeout = False
-        t0 = time.time()
-        while not error and not timeout and not requests_semaphore.acquire(block=True, timeout=1.0):
-            timeout = (time.time() - t0) > TIMEOUT
-            with lock:
-                error = (status.get(-1) != None)
-        if timeout:
-            tsprint("Exceeded timeout {} seconds.".format(TIMEOUT))
-        if error or timeout:
-            break
-        while not error and not timeout and not appends_semaphore.acquire(block=True, timeout=1.0):
-            timeout = (time.time() - t0) > TIMEOUT
-            with lock:
-                error = (status.get(-1) != None)
-        if timeout:
-            tsprint("Exceeded timeout {} seconds.".format(TIMEOUT))
-        if error or timeout:
-            break
-        next_semaphore = multiprocessing.Semaphore(1)
-        next_semaphore.acquire()
-        multiprocessing.Process(
-            target=fetch_chunk,
-            args=[s3_bucket, s3_key, destination_download, n, N, file_size, status, last_semaphore, next_semaphore, requests_semaphore, appends_semaphore, lock]
-        ).start()
-        last_semaphore = next_semaphore
-    # each process waits for the previous one, so joining the last joins all
-    last_semaphore.acquire()
-    if len(status) == N and all(s == "succeeded" for s in status.values()):
-        if destination != "-":
-            os.rename(destination_download, destination)
-        tsprint("Great success.")
-    else:
-        # tsprint(str(sorted(status.items())))
-        if destination != "-":
-            safe_remove(destination_download)
-        tsprint("There were some failures, sorry.")
-        sys.exit(-1)
 
 if __name__ == "__main__":
-    try:
-        main(s3_uri=sys.argv[1],
-             destination=(len(sys.argv) > 2 and sys.argv[2]) or "-")
-    except KeyboardInterrupt:
-        pass
-    except:
-        tsprint(help_text)
-        raise
+    tsprint("WARNING:  The s3cp.py script is deprecated.  Use 's3mi cp' or 's3mi cat' instead.")
+    if sys.argv[2] == "-":
+        check_call(["s3mi", "cat", sys.argv[1]])
+    else:
+        safe_remove(sys.argv[2])
+        with open(sys.argv[2], "ab") as dest:
+            check_call(["s3mi", "cat", sys.argv[1]], stdout=dest)

--- a/scripts/s3mi
+++ b/scripts/s3mi
@@ -1,0 +1,226 @@
+#!/usr/bin/env python
+#
+# Tested under python 2.7, 3.5, 3.6.
+#
+# Copyright (c) 2017 Chan Zuckerberg Initiative, see LICENSE.
+
+import threading
+import multiprocessing
+import subprocess
+
+try:
+    from Queue import Queue
+except:
+    from queue import Queue
+
+import os
+import sys
+import time
+import traceback
+
+help_text = """
+S3MI:  Download huge files from S3 to EC2, fast.
+
+Usage:
+    https://github.com/chanzuckerberg/s3mi/blob/master/README.md
+
+License:
+    https://github.com/chanzuckerberg/s3mi/blob/master/LICENSE
+"""
+
+EXABYTE = 2**50
+
+# The goal is to stream from S3 at 2GB/sec.
+# As each request is limited to 1 Gbit/sec, we need 16+ concurrent requests.
+MAX_CONCURRENT_REQUESTS = 36
+
+# Max RAM required = MAX_PENDING_APPENDS * MAX_SEGMENT_SIZE
+MAX_PENDING_APPENDS = 256
+MAX_SEGMENT_SIZE = 256*1024*1024
+
+# Max time in seconds without a single chunk completing its fetch.
+TIMEOUT = 120
+
+
+def tsprint(msg):
+    sys.stderr.write(msg)
+    sys.stderr.write("\n")
+
+
+def num_segments(file_size):
+    return (file_size + MAX_SEGMENT_SIZE - 1) // MAX_SEGMENT_SIZE
+
+
+def segment_start(n, N, size):
+    assert size < EXABYTE, "Sizes over an exabyte get squished by conversion to 64-bit float."
+    return int(size * (float(n) / float(N)))
+
+
+def part_filename(destination, n, N):
+    return "part.{N}.{n:06d}.{destination}".format(destination=destination, N=N, n=n)
+
+
+def concatenate_chunk(destination, segment_bytes):
+    with open(destination, "ab") as dest_file:
+        dest_file.write(segment_bytes)
+
+
+def safe_remove(f):
+    try:
+        if os.path.exists(f):
+            os.remove(f)
+    except:
+        pass
+
+
+def get_file_size(s3_uri):
+    command_str = "aws s3 ls {s3_uri}".format(s3_uri=s3_uri)
+    tsprint(command_str)
+    result = subprocess.check_output(command_str.split())
+    return int(result.split()[2])
+
+
+def s3_bucket_and_key(s3_uri):
+    prefix = "s3://"
+    assert s3_uri.startswith(prefix)
+    return s3_uri[len(prefix):].split("/", 1)
+
+
+def main_cp(s3_uri, destination):
+    tsprint("Note:  This version of 's3mi cp' uses 's3 cat'.  TODO: Use mmap.")
+    safe_remove(destination)
+    with open(destination, "ab") as dest:
+        sys.stdout = dest
+        return main_cat(s3_uri, do_not_reopen=True)
+
+
+def main_raid(volume_name, *optional_args):
+    raise Exception("Command 'raid' is not yet implemented.")
+
+
+def initiate_fetch(s3_bucket, s3_key, part, n, N, size, request_tokens, errors):
+    fetcher_subproc = None
+    watchdog = None
+    def kill():
+        if fetcher_subproc:
+            fetcher_subproc.terminate()
+    def note_error():
+        with errors[0]:
+            errors[1] += 1
+        tsprint("Fetching part '{}' failed.".format(part))
+    def wait_and_release():
+        try:
+            if fetcher_subproc and fetcher_subproc.wait() != 0:
+                note_error()
+        except:
+            note_error()
+            raise
+        finally:
+            request_tokens.release()
+            if watchdog:
+                watchdog.cancel()
+    try:
+        first = segment_start(n, N, size)
+        last = segment_start(n + 1, N, size) - 1  # aws api wants inclusive bounds
+        command_str = "aws s3api get-object --range bytes={rfrom}-{rto} --bucket {bucket} --key {key} {part}".format(
+            rfrom=first, rto=last, bucket=s3_bucket, key=s3_key, part=part)
+        safe_remove(part)
+        os.mkfifo(part)
+        with open("/dev/null", "ab") as devnull:
+            fetcher_subproc = subprocess.Popen(command_str.split(), stdout=devnull)
+    except:
+        with errors[0]:
+            errors[1] += 1
+    finally:
+        if fetcher_subproc:
+            watchdog = threading.Timer(TIMEOUT, kill)
+            watchdog.start()
+        threading.Thread(target=wait_and_release).start()
+
+
+def append(part, baton):
+    with open(part, 'rb') as pf:
+        segment_bytes = pf.read()
+    baton.acquire()
+    sys.stdout.write(segment_bytes)
+
+
+def main_cat(s3_uri, do_not_reopen=False):
+    file_size = get_file_size(s3_uri)
+    tsprint("File size is {:3.1f} GB ({} bytes).".format(file_size/(2**30), file_size))
+    s3_bucket, s3_key = s3_bucket_and_key(s3_uri)
+    N = num_segments(file_size)
+    tsprint("Fetching {} segments.".format(N))
+    active_appenders = Queue(MAX_PENDING_APPENDS)
+    request_tokens = threading.Semaphore(MAX_CONCURRENT_REQUESTS)
+    errors = [threading.RLock(), 0]
+    if not do_not_reopen:
+        sys.stdout = os.fdopen(sys.stdout.fileno(), 'ab')
+    def error_state():
+        with errors[0]:
+            return errors[1]
+    def baton_passer_loop():
+        while True:
+            part, appender, baton = active_appenders.get()
+            if appender == None:
+                break
+            try:
+                baton.release()
+                t0 = time.time()
+                while appender.is_alive() and not error_state() and time.time() - t0 < TIMEOUT:
+                    appender.join(5.0)
+                if error_state() and appender.is_alive():
+                    appender.terminate()
+                assert appender.exitcode == 0
+            except:
+                with errors[0]:
+                    errors[1] += 1
+                tsprint("Error appending part '{}'.".format(part))
+            finally:
+                safe_remove(part)
+    baton_passer = threading.Thread(target=baton_passer_loop)
+    baton_passer.start()
+    pid = os.getpid()
+    try:
+        for n in range(N):
+            request_tokens.acquire()
+            if error_state():
+                break
+            part = part_filename("download-{}".format(pid), n, N)
+            baton = multiprocessing.Semaphore(1)
+            baton.acquire()
+            initiate_fetch(s3_bucket, s3_key, part, n, N, file_size, request_tokens, errors)
+            appender = multiprocessing.Process(target=append, args=[part, baton])
+            appender.start()
+            active_appenders.put((part, appender, baton), block=True, timeout=TIMEOUT)
+    finally:
+        active_appenders.put((None, None, None))
+        baton_passer.join()
+    if error_state():
+        return 1
+    return 0
+
+
+def main(argv):
+    assert len(argv) >= 3
+    s3mi, command, args = argv[0], argv[1], argv[2:]
+    if command == "cp":
+        result = main_cp(*args)
+    elif command == "cat":
+        result = main_cat(*args)
+    elif command == "raid":
+        result = main_raid(*args)
+    else:
+        raise Exception("Unsupported command '{}', see usage.".format(command))
+    return result
+
+
+if __name__ == "__main__":
+    try:
+        exitcode = main(sys.argv)
+        if exitcode != 0:
+            sys.exit(exitcode)
+    except:
+        traceback.print_exc()
+        tsprint(help_text)
+        sys.exit(1)

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,4 +2,4 @@
 universal=1
 [flake8]
 max-line-length=8192
-disable: C0111, C0103, C0121, R0913
+disable: C0111, C0103, C0121, R0913, W0702, R0914

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ install_requires = [line.rstrip() for line in open(os.path.join(os.path.dirname(
 
 setup(
     name="s3mi",
-    version="0.0.5",
+    version="0.3.0",
     url='https://github.com/chanzuckerberg/s3mi',
     license=open("LICENSE").readline().strip(),
     author='S3MI contributors',
@@ -16,7 +16,7 @@ setup(
     extras_require={},
     packages=None,
     package_dir=None,
-    scripts=glob.glob('scripts/*.py'),
+    scripts=glob.glob('scripts/*'),
     data_files=None,
     platforms=['MacOS X', 'Posix'],
     zip_safe=False,


### PR DESCRIPTION
much simpler code, handles errors gracefully, works faster!

also: s3cp.py is now deprecated, use new 's3mi cp' and s3mi cat'
commands