### PR TITLE
more gradual scaling of RAM to support AWS instances used in idseq batch jobs

### DIFF
--- a/scripts/s3mi
+++ b/scripts/s3mi
@@ -316,10 +316,14 @@ def adjust_RAM_params():
         # Mac laptop or tiny AWS instance => use 2GB RAM for buffers
         MAX_SEGMENTS_IN_RAM = 6
         MAX_CONCURRENT_REQUESTS = 3
-    elif gigs < 120:
-        # Smallish AWS instance => use 8GB RAM for buffers
-        MAX_SEGMENTS_IN_RAM = 24
-        MAX_CONCURRENT_REQUESTS = 12
+    elif gigs <= 128:
+        # Smallish AWS instance => use 6GB RAM for buffers
+        MAX_SEGMENTS_IN_RAM = 16
+        MAX_CONCURRENT_REQUESTS = 7
+    elif gigs <= 384:
+        # Medium AWS instance => use 12GB RAM for buffers
+        MAX_SEGMENTS_IN_RAM = 32
+        MAX_CONCURRENT_REQUESTS = 15
 
 
 def main_cat(s3_uri):

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ install_requires = [line.rstrip() for line in open(os.path.join(os.path.dirname(
 
 setup(
     name="s3mi",
-    version="0.6.0",
+    version="0.7",
     url='https://github.com/chanzuckerberg/s3mi',
     license=open("LICENSE").readline().strip(),
     author='S3MI contributors',


### PR DESCRIPTION
By default s3mi uses 27 GB of RAM for buffers.  While fine for machines with 0.5 TB of RAM, this overwhelms the much smaller instances used in the idseq batch jobs.  Particularly considering that s3mi isn't the only heavy tool running on those instances.

This change downsizes the amount of RAM used for s3mi buffers based on machine RAM size.  The goal is to reliably support the execution of 2 or 3 concurrent s3mi downloads on the instance types used in idseq batch jobs.